### PR TITLE
Allow internal IDs in find() to support fixtures

### DIFF
--- a/lib/hashids_rails.rb
+++ b/lib/hashids_rails.rb
@@ -38,8 +38,8 @@ module HashidsRails
       true
     end
 
-    def dehash_id(hashed_id)
-      HashidsRails.show(hashed_id, self.hash_salt)
+    def dehash_id(input)
+      input.is_a?(Fixnum) ? input : HashidsRails.show(input, self.hash_salt)
     end
 
     # Generate a default salt from the Model name


### PR DESCRIPTION
I got some issues with my tests when using this gem. Got the error `NoMethodError Exception: undefined method 'empty?' for NNNNN:Fixnum`. I tracked down the source of the error in some code in `hashids`. The problem seems to be that when loading fixtures, calls are being made to Model.find() with the internal/numeric IDs.

I added a check to see if the requested ID is a Fixnum, and made it skip dehashing if that is the case.